### PR TITLE
Allow both goals and commands to be associated with different locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 compiled/
+doc/
 *~
 /scribblings/*.css
 /scribblings/*.js

--- a/demo.rkt
+++ b/demo.rkt
@@ -31,7 +31,8 @@
 ;; This example uses a syntax parameter to propagate the surrounding expression
 ;; context, attaching the todo-item to the context if one exists.
 (begin-for-syntax
-  (struct todo-item (loc full summary) #:prefab))
+  (struct located (loc value) #:prefab)
+  (struct goal (full summary) #:prefab))
 
 (require racket/stxparam racket/splicing)
 
@@ -49,7 +50,7 @@
   (define ctx (or (syntax-parameter-value #'definition-context) stx))
   (syntax-parse stx
     [(_ msg:string)
-     (define item (todo-item ctx (syntax->datum #'msg) #f))
+     (define item (located ctx (goal (syntax->datum #'msg) #f)))
      (syntax-property (syntax/loc stx (error 'inner-todo msg)) 'goal item)]))
 
 ;; The entire definition containing the TODO is highlighted as a goal now.

--- a/main.rkt
+++ b/main.rkt
@@ -1,4 +1,4 @@
 #lang racket/base
 (require "private/goal-info.rkt")
 
-(provide (struct-out command) (struct-out todo-item))
+(provide (struct-out command) (struct-out goal) (struct-out located))

--- a/private/goal-info.rkt
+++ b/private/goal-info.rkt
@@ -1,12 +1,18 @@
 #lang racket
 
-(provide (struct-out goal) (struct-out command) (struct-out todo-item))
+(provide (struct-out goal) (struct-out command) (struct-out located))
 
-;; Alternative goal interface
-(struct todo-item (location full summary) #:prefab)
+;; A SourceLocation is either a syntax object, a srcloc struct, or a
+;; list or vector containing the source, line, column, position, and
+;; span. See source-location? from syntax/srcloc.
 
 ;; Indicate the presence of a goal
 (struct goal (full summary) #:prefab)
 
 ;; Indicate the potential availability of an interactive editing command
 (struct command (name module-path function arguments) #:prefab)
+
+;; Locate a goal or command at a different location from the current syntax
+(struct located (location value) #:prefab)
+
+;; A [Located X] is a (located SourceLocation X)

--- a/scribblings/todo-list.scrbl
+++ b/scribblings/todo-list.scrbl
@@ -26,22 +26,21 @@ Open @tt{demo.rkt} from the package's source for a very simple hole macro and tw
 
 The following syntax properties are recognized by the Todo List:
 @itemlist[@item{@racket['goal]: the complete goal to be shown in the Todo List. A goal is either a
-           string or an instance of the @racket[todo-item] prefab struct.}
+           string, an instance of the @racket[goal] prefab struct, or an instance of
+           @racket[located] with a @racket[goal] inside.}
           @item{@racket['editing-command]: an editing
-           command to be shown in a region, which should be an instance of @racket[command].}]
+           command to be shown in a region. A command is either an instance of @racket[command]
+           or an instance of @racket[located] with a @racket[command] inside.}]
 To avoid a runtime dependency between your language and the Todo List, it is better to paste in the
-source for the prefab structs @racket[todo-item] and @racket[command].
+source for the prefab structs @racket[goal], @racket[command], and @racket[located].
 
-@defstruct*[todo-item ([location source-location?]
-                       [full string?]
-                       [summary (or/c #f string?)]) #:prefab]{
- A @racket[todo-item] represents a goal to be shown in the todo list. The goal is presented at
- @racket[loc], unless @racket[location] is @racket[#f], in which case the syntax object to which the
- goal is attached is used for its source location. The contents of @racket[full] are used as the
+@defstruct*[goal ([full string?]
+                  [summary (or/c #f string?)]) #:prefab]{
+ A @racket[goal] represents a goal to be shown in the todo list.
+ The contents of @racket[full] are used as the
  contents of the goal details, and if @racket[summary] is @racket[#f], then @racket[full] is also
  used as the summary for the Todo List. If @racket[summary] is a string, then it is used as the
- summary. Only one goal is permitted for a region: if the @racket[location] fields cause multiple
- goals to overlap, then one will replace the other in an unspecified order.
+ summary.
 }
 
 @defstruct*[command ([name string?]
@@ -71,4 +70,14 @@ source for the prefab structs @racket[todo-item] and @racket[command].
  is invoked.
 }
 
+@defstruct*[located ([location source-location?]
+                     [value any/c])
+            #:prefab]{
+ A goal or command can be put inside a @racket[located] struct. The @racket[location] field
+ contains the region to associate it with, and the @racket[value] field contains the goal or
+ command.
+
+ Only one goal is permitted for a region: if the @racket[location] fields cause multiple
+ goals to overlap, then one will replace the other in an unspecified order.
+}
 


### PR DESCRIPTION
This pull request solves issue #5 for both goals and commands. For either one, a macro can wrap it in a `located` struct like this:
```racket
(located ...loc... (goal ...full... ...summary...))
(located ...loc... (command ...command stuff...))
```