### PR TITLE
remove string syntax class

### DIFF
--- a/demo.rkt
+++ b/demo.rkt
@@ -50,7 +50,7 @@
 (define-syntax (inner-TODO stx)
   (define ctx (or (syntax-parameter-value #'definition-context) stx))
   (syntax-parse stx
-    [(_ msg:string)
+    [(_ msg:str)
      (define item
        (located ctx
                 (todo-item (syntax->datum #'msg)


### PR DESCRIPTION
The string syntax class for syntax-parse was added sometime around
racket 6.9-6-10. By removing that syntax class we can support
many more versions of racket (at least back to 6.5, possibly
earlier).